### PR TITLE
Added a backup for config in termux-desktop.sh

### DIFF
--- a/termux-desktop.sh
+++ b/termux-desktop.sh
@@ -11,6 +11,7 @@ tar -xvJf zsh.tar.xz
 chsh -s zsh 
 echo "killall pulseaudio &>/dev/null" >>~/.zshrc 
 echo "pulseaudio --start --exit-idle-time=-1; pacmd load-module module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1" >>~/.zshrc 
+mv ~/.config ~/.config.backup 
 rm -rf ~/.config 
 wget https://github.com/atamshkai/Termux-Desktop/releases/download/Termux-Desktop/termux-desktop.tar.xz
 tar -xvJf termux-desktop.tar.xz


### PR DESCRIPTION
Added a line before removing the ~/.config that creates a backup for it stored in ~/.config.backup

(Please don't delete the user's config directory without asking)